### PR TITLE
fix: PostgreSQLコンテナにボリューム永続化を追加

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       POSTGRES_USER: ${PG_USER:-postgres}
       POSTGRES_PASSWORD: ${PG_PASSWORD:-postgres}
       POSTGRES_DB: ${PG_DB:-postgres}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
 
   # --- Firebase Emulator Suite (認証・Storage・FCM) ---
   firebase-emulator:
@@ -104,3 +106,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary

- PostgreSQLコンテナに `postgres-data` Named Volumeを追加し、`docker compose down` 後もデータが永続化されるようにした
- トップレベルに `volumes` セクションを追加

## Changes

- `docker-compose.yaml`: postgresサービスに `volumes` マウントを追加
- `docker-compose.yaml`: トップレベルに `postgres-data` Named Volume定義を追加

## Test plan

- [ ] `docker compose up -d postgres` でコンテナ起動を確認
- [ ] `docker volume ls` で `postgres-data` ボリュームが作成されていることを確認
- [ ] データ投入後に `docker compose down && docker compose up -d postgres` でデータが保持されていることを確認
- [ ] `docker compose config` でYAML構文エラーがないことを確認（実施済み）

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)