### PR TITLE
fix: BigQuery Emulatorにplatform指定を追加してarm64環境で動作可能にする (#33)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,6 @@ services:
     container_name: bigquery-emulator
     image: ghcr.io/goccy/bigquery-emulator:latest
     profiles:
-      - services
       - bigquery
     command: ["--project", "${BIGQUERY_PROJECT_ID:-frienda-local}", "--port", "9050"]
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,7 +66,9 @@ services:
   bigquery-emulator:
     container_name: bigquery-emulator
     image: ghcr.io/goccy/bigquery-emulator:latest
+    platform: linux/amd64
     profiles:
+      - services
       - bigquery
     command: ["--project", "${BIGQUERY_PROJECT_ID:-frienda-local}", "--port", "9050"]
     ports:


### PR DESCRIPTION
## Summary
- `bigquery-emulator` サービスに `platform: linux/amd64` を追加し、arm64環境 (Apple Silicon) でもQEMUエミュレーション経由で動作するようにした
- `services` プロファイルは維持し、`make dev-all` で他サービスと一括起動可能

## 背景
- bigquery-emulatorはamd64イメージのみ提供（上流のZetaSQL C++ライブラリがarm64未対応）
- `platform: linux/amd64` 指定でDockerがQEMUエミュレーションを自動適用

## Test plan
- [ ] arm64環境 (Apple Silicon Mac) で `make dev-up-all` が成功する
- [ ] `make dev-bigquery` で個別起動が動作する
- [ ] amd64環境で既存動作に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>