### PR TITLE
fix: Firebase EmulatorのDockerfileにJavaランタイムを追加

### DIFF
--- a/docker/firebase-emulator/Dockerfile
+++ b/docker/firebase-emulator/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:20-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends default-jre-headless \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g firebase-tools
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Firebase Emulatorコンテナ (`docker/firebase-emulator/Dockerfile`) のベースイメージ `node:20-slim` にJavaが含まれておらず、起動時に `Could not spawn java -version` エラーで失敗していた問題を修正
- `default-jre-headless` パッケージのインストールを追加し、aptキャッシュを削除してイメージサイズを最小限に抑制

## Test plan

- [ ] `make dev-firebase` でFirebase Emulatorが正常に起動することを確認
- [ ] Auth EmulatorとStorage Emulatorが両方動作することを確認

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)