### PR TITLE
fix: Firebase認証のプロジェクトID不一致を修正しEmulator対応を統一

### DIFF
--- a/services/webui/apps/client/.env.example
+++ b/services/webui/apps/client/.env.example
@@ -16,18 +16,18 @@ NEXT_PUBLIC_CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT=master
 
 # --- Firebase（認証） ---
-# ローカル開発(Emulator)と本番/ステージングのどちらか一方を有効にしてください
+# [A]と[B]のどちらか一方を有効にしてください（両方有効にしないこと）
 #
 # [A] ローカル開発: Firebase Emulator を使用する場合（make dev-firebase で起動）
-NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
-FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
-FIREBASE_PROJECT_ID=frienda-local
+# NEXT_PUBLIC_ はクライアント側(ブラウザ)、FIREBASE_AUTH_EMULATOR_HOST はサーバー側(Admin SDK)用
+# NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+# FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+# FIREBASE_PROJECT_ID=frienda-local
 #
 # [B] 本番/ステージング: Firebaseコンソールからサービスアカウントキーを取得
-# [A]を使う場合は[B]を全てコメントアウトしてください
-# FIREBASE_PROJECT_ID=
-# FIREBASE_CLIENT_EMAIL=
-# FIREBASE_PRIVATE_KEY=
+FIREBASE_PROJECT_ID=
+FIREBASE_CLIENT_EMAIL=
+FIREBASE_PRIVATE_KEY=
 
 # --- Stripe（サーバーサイド決済） ---
 STRIPE_SECRET_KEY=

--- a/services/webui/apps/client/.env.example
+++ b/services/webui/apps/client/.env.example
@@ -16,15 +16,18 @@ NEXT_PUBLIC_CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT=master
 
 # --- Firebase（認証） ---
-# ローカル開発: Firebase Emulator を使用する場合（make dev-firebase で起動）
-# 下記3行のコメントを外し、さらに FIREBASE_PROJECT_ID= の空行を削除またはコメントアウトしてください
-# NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
-# FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
-# FIREBASE_PROJECT_ID=frienda-local
-# 本番/ステージング環境: Firebaseコンソールからサービスアカウントキーを取得
-FIREBASE_PROJECT_ID=
-FIREBASE_CLIENT_EMAIL=
-FIREBASE_PRIVATE_KEY=
+# ローカル開発(Emulator)と本番/ステージングのどちらか一方を有効にしてください
+#
+# [A] ローカル開発: Firebase Emulator を使用する場合（make dev-firebase で起動）
+NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+FIREBASE_PROJECT_ID=frienda-local
+#
+# [B] 本番/ステージング: Firebaseコンソールからサービスアカウントキーを取得
+# [A]を使う場合は[B]を全てコメントアウトしてください
+# FIREBASE_PROJECT_ID=
+# FIREBASE_CLIENT_EMAIL=
+# FIREBASE_PRIVATE_KEY=
 
 # --- Stripe（サーバーサイド決済） ---
 STRIPE_SECRET_KEY=

--- a/services/webui/apps/client/.env.example
+++ b/services/webui/apps/client/.env.example
@@ -15,7 +15,12 @@ NEXT_PUBLIC_CTF_CDA_ACCESS_TOKEN=
 NEXT_PUBLIC_CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT=master
 
-# --- Firebase Admin（サーバーサイド認証） ---
+# --- Firebase（認証） ---
+# ローカル開発: Firebase Emulator を使用する場合（make dev-firebase で起動）
+# NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+# FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+# FIREBASE_PROJECT_ID=frienda-local
+# 本番/ステージング環境: Firebaseコンソールからサービスアカウントキーを取得
 FIREBASE_PROJECT_ID=
 FIREBASE_CLIENT_EMAIL=
 FIREBASE_PRIVATE_KEY=

--- a/services/webui/apps/client/.env.example
+++ b/services/webui/apps/client/.env.example
@@ -17,6 +17,7 @@ NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT=master
 
 # --- Firebase（認証） ---
 # ローカル開発: Firebase Emulator を使用する場合（make dev-firebase で起動）
+# 下記3行のコメントを外し、さらに FIREBASE_PROJECT_ID= の空行を削除またはコメントアウトしてください
 # NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
 # FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
 # FIREBASE_PROJECT_ID=frienda-local

--- a/services/webui/apps/client/config.ts
+++ b/services/webui/apps/client/config.ts
@@ -1,6 +1,11 @@
 import { initializeApp } from "@firebase/app";
-import { getAuth } from "@firebase/auth";
+import { connectAuthEmulator, getAuth } from "@firebase/auth";
 import { getStorage } from "firebase/storage";
+
+const firebaseConfigEmulator = {
+  apiKey: "fake-api-key",
+  projectId: "frienda-local",
+};
 
 const firebaseConfigDev = {
   apiKey: "AIzaSyAkYBfsIsL-PALnx6-20rJB1eEGAXMUYF8",
@@ -22,7 +27,12 @@ const firebaseConfigPrd = {
   measurementId: "G-BSD0532YHD",
 };
 
+const emulatorHost = process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST;
+
 const getFirebaseConfig = () => {
+  if (emulatorHost) {
+    return firebaseConfigEmulator;
+  }
   switch (process.env.NEXT_PUBLIC_ENV) {
     case "production":
       return firebaseConfigPrd;
@@ -36,4 +46,7 @@ const getFirebaseConfig = () => {
 const firebaseConfig = getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+if (emulatorHost) {
+  connectAuthEmulator(auth, `http://${emulatorHost}`);
+}
 export const storage = getStorage(app);

--- a/services/webui/apps/client/config.ts
+++ b/services/webui/apps/client/config.ts
@@ -49,8 +49,10 @@ export const auth = getAuth(app);
 if (emulatorHost) {
   try {
     connectAuthEmulator(auth, `http://${emulatorHost}`);
-  } catch {
-    // Already connected (e.g. HMR re-evaluation)
+  } catch (e) {
+    if (!(e instanceof Error) || !e.message.includes("already")) {
+      console.error("Failed to connect to Auth Emulator:", e);
+    }
   }
 }
 export const storage = getStorage(app);

--- a/services/webui/apps/client/config.ts
+++ b/services/webui/apps/client/config.ts
@@ -46,9 +46,11 @@ const getFirebaseConfig = () => {
 const firebaseConfig = getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
-let emulatorConnected = false;
-if (emulatorHost && !emulatorConnected) {
-  connectAuthEmulator(auth, `http://${emulatorHost}`);
-  emulatorConnected = true;
+if (emulatorHost) {
+  try {
+    connectAuthEmulator(auth, `http://${emulatorHost}`);
+  } catch {
+    // Already connected (e.g. HMR re-evaluation)
+  }
 }
 export const storage = getStorage(app);

--- a/services/webui/apps/client/config.ts
+++ b/services/webui/apps/client/config.ts
@@ -48,7 +48,7 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 if (emulatorHost) {
   try {
-    connectAuthEmulator(auth, `http://${emulatorHost}`);
+    connectAuthEmulator(auth, `http://${emulatorHost}`, { disableWarnings: true });
   } catch (e) {
     if (!(e instanceof Error) || !e.message.includes("already")) {
       console.error("Failed to connect to Auth Emulator:", e);

--- a/services/webui/apps/client/config.ts
+++ b/services/webui/apps/client/config.ts
@@ -46,7 +46,7 @@ const getFirebaseConfig = () => {
 const firebaseConfig = getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
-if (emulatorHost) {
+if (emulatorHost && !(auth as any).emulatorConfig) {
   connectAuthEmulator(auth, `http://${emulatorHost}`);
 }
 export const storage = getStorage(app);

--- a/services/webui/apps/client/config.ts
+++ b/services/webui/apps/client/config.ts
@@ -46,7 +46,9 @@ const getFirebaseConfig = () => {
 const firebaseConfig = getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
-if (emulatorHost && !(auth as any).emulatorConfig) {
+let emulatorConnected = false;
+if (emulatorHost && !emulatorConnected) {
   connectAuthEmulator(auth, `http://${emulatorHost}`);
+  emulatorConnected = true;
 }
 export const storage = getStorage(app);

--- a/services/webui/apps/client/firebase-admin.ts
+++ b/services/webui/apps/client/firebase-admin.ts
@@ -4,7 +4,10 @@ export function initAdmin() {
   if (getApps().length === 0) {
     if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
       // Firebase Emulator使用時はプロジェクトIDのみで初期化
-      initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || "frienda-local" });
+      if (!process.env.FIREBASE_PROJECT_ID) {
+        throw new Error("FIREBASE_PROJECT_ID is required when using Firebase Auth Emulator");
+      }
+      initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID });
     } else {
       initializeApp({
         credential: cert({

--- a/services/webui/apps/client/firebase-admin.ts
+++ b/services/webui/apps/client/firebase-admin.ts
@@ -4,7 +4,7 @@ export function initAdmin() {
   if (getApps().length === 0) {
     if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
       // Firebase Emulator使用時はプロジェクトIDのみで初期化
-      initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID });
+      initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || "frienda-local" });
     } else {
       initializeApp({
         credential: cert({

--- a/services/webui/apps/client/firebase-admin.ts
+++ b/services/webui/apps/client/firebase-admin.ts
@@ -9,11 +9,14 @@ export function initAdmin() {
       }
       initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID });
     } else {
+      if (!process.env.FIREBASE_PROJECT_ID || !process.env.FIREBASE_CLIENT_EMAIL || !process.env.FIREBASE_PRIVATE_KEY) {
+        throw new Error("FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY are required");
+      }
       initializeApp({
         credential: cert({
           projectId: process.env.FIREBASE_PROJECT_ID,
           clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-          privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+          privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, "\n"),
         }),
       });
     }

--- a/services/webui/apps/client/firebase-admin.ts
+++ b/services/webui/apps/client/firebase-admin.ts
@@ -2,12 +2,17 @@ import { getApps, initializeApp, cert } from "firebase-admin/app";
 
 export function initAdmin() {
   if (getApps().length === 0) {
-    initializeApp({
-      credential: cert({
-        projectId: process.env.FIREBASE_PROJECT_ID,
-        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
-      }),
-    });
+    if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+      // Firebase Emulator使用時はプロジェクトIDのみで初期化
+      initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID });
+    } else {
+      initializeApp({
+        credential: cert({
+          projectId: process.env.FIREBASE_PROJECT_ID,
+          clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+          privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+        }),
+      });
+    }
   }
 }

--- a/services/webui/apps/client/firebase-admin.ts
+++ b/services/webui/apps/client/firebase-admin.ts
@@ -9,7 +9,11 @@ export function initAdmin() {
       }
       initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID });
     } else {
-      if (!process.env.FIREBASE_PROJECT_ID || !process.env.FIREBASE_CLIENT_EMAIL || !process.env.FIREBASE_PRIVATE_KEY) {
+      if (
+        !process.env.FIREBASE_PROJECT_ID ||
+        !process.env.FIREBASE_CLIENT_EMAIL ||
+        !process.env.FIREBASE_PRIVATE_KEY
+      ) {
         throw new Error("FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY are required");
       }
       initializeApp({


### PR DESCRIPTION
## Summary
- Firebase Client SDK（config.ts）とAdmin SDK（firebase-admin.ts）でプロジェクトIDが不一致だった問題を修正
- `NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST`設定時にクライアント/サーバー両方がEmulatorに接続し、`projectId: frienda-local`で統一
- `.env.example`にEmulator設定のコメント例を追加

Closes #37

## Test plan
- [ ] `make dev-firebase`でFirebase Emulatorを起動
- [ ] `make webui-client-dev`でNext.js開発サーバーを起動
- [ ] ブラウザでログインし、`POST /api/auth/verify`が401ではなく正常応答することを確認
- [ ] Emulator設定を外した状態で、従来のリモートFirebase認証が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)